### PR TITLE
fix #4 make Zlib optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
  - WebAPI.new url, opts={}
    - Make an WebAPI object to be used to call APIs whose base url is `url`
    - Supported keys in `opts`:
-     - :accept_encoding => str
+     - :accept_encoding => str (mruby-zlib is required)
        - acceptable response encoding
          (supported type: "gzip" or "deflate")
      - :certs => str
        - pathname of the file contains trusted root CA certificate(s)
-     - :content_encoding => str
+     - :content_encoding => str (mruby-zlib is required)
        - type of request body encoding
          (supported type: "gzip" or "deflate")
      - :content_type => str

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -7,5 +7,5 @@ MRuby::Gem::Specification.new('mruby-webapi') do |spec|
   spec.add_dependency 'mruby-sprintf'
   spec.add_dependency 'mruby-string-ext'
   spec.add_dependency 'mruby-tls-openssl'
-  spec.add_dependency 'mruby-zlib'
+  #spec.add_dependency 'mruby-zlib' # Optional
 end

--- a/test/webapi.rb
+++ b/test/webapi.rb
@@ -28,23 +28,44 @@ assert('WebAPI::Response#_join_chunks') do
   assert_equal "mruby-webapi", r.body
 end
 
-assert('WebAPI::Response response with Content-Encoding') do
-  text =  "HTTP/1.1 200 OK\r\n"
-  text += "Content-Encoding: gzip\r\n"
-  text += "\r\n"
-  text += "#{Zlib.gzip("mruby-webapi")}\r\n"
-  text += "\r\n"
-  r = WebAPI::Response.new text
-  assert_equal "mruby-webapi", r.body
-end
+if Object.const_defined? :Zlib
+  assert('WebAPI::Response response with Content-Encoding') do
+    text =  "HTTP/1.1 200 OK\r\n"
+    text += "Content-Encoding: gzip\r\n"
+    text += "\r\n"
+    text += "#{Zlib.gzip("mruby-webapi")}"
+    r = WebAPI::Response.new text
+    assert_equal "mruby-webapi", r.body
+  end
 
-assert('WebAPI::Response broken response with Content-Encoding') do
-  text =  "HTTP/1.1 200 OK\r\n"
-  text += "Content-Encoding: gzip\r\n"
-  text += "\r\n"
-  text += "It is not a gzip\r\n"
-  text += "\r\n"
-  assert_raise(WebAPI::ResponseError) do
-    WebAPI::Response.new text
+  assert('WebAPI::Response broken response with Content-Encoding') do
+    text =  "HTTP/1.1 200 OK\r\n"
+    text += "Content-Encoding: gzip\r\n"
+    text += "\r\n"
+    text += "It is not a gzip"
+    assert_raise(WebAPI::ResponseError) do
+      WebAPI::Response.new text
+    end
+  end
+else
+  assert('WebAPI.new without mruby-zlib') do
+    assert_raise(WebAPI::UnSupportedOptionError) do
+      WebAPI.new("http://expample.com", {:content_encoding => "gzip"})
+    end
+    assert_raise(WebAPI::UnSupportedOptionError) do
+      WebAPI.new("http://expample.com", {:accept_encoding => "gzip"})
+    end
+  end
+
+  assert('WebAPI::Response with Content-Encoding but no mruby-zlib') do
+    text =  "HTTP/1.1 200 OK\r\n"
+    text += "Content-Encoding: gzip\r\n"
+    text += "\r\n"
+    # Zlib.gzip("mruby-webapi")
+    text += "\037\213\b\000\000\000\000\000\000\003\313-*M\252\324-OMJ,\310\004\000s\216x\220\f\000\000\000"
+    r = WebAPI::Response.new text
+    assert_equal("\037\213\b\000\000\000\000\000\000\003\313-*M\252\324-OMJ,\310\004\000s\216x\220\f\000\000\000",
+                 r.body) #passthrough
+    assert_equal r.headers["content-encoding"], "gzip"
   end
 end


### PR DESCRIPTION
:content_encoding and :accept_encoding are enabled only if
mruby-zlib linked.

Signed-off-by: Go Saito <gos@iij.ad.jp>